### PR TITLE
Fix n98-magerun unable to clear cache

### DIFF
--- a/app/code/community/Lesti/Fpc/Model/Observer/Clean.php
+++ b/app/code/community/Lesti/Fpc/Model/Observer/Clean.php
@@ -23,20 +23,15 @@ class Lesti_Fpc_Model_Observer_Clean
         $this->_getFpc()->getFrontend()->clean(Zend_Cache::CLEANING_MODE_OLD);
     }
 
-    public function adminhtmlCacheFlushAll()
+    public function flushFpc(Varien_Event_Observer $observer)
     {
-        $this->_getFpc()->clean();
-    }
-
-    public function controllerActionPredispatchAdminhtmlCacheMassRefresh()
-    {
-        $types = Mage::app()->getRequest()->getParam('types');
-        if ($this->_getFpc()->isActive()) {
-            if ((is_array($types) && in_array(self::CACHE_TYPE, $types)) ||
-                $types == self::CACHE_TYPE) {
-                $this->_getFpc()->clean();
-            }
+        // type only exist for event adminhtml_cache_refresh_type
+        $type = $observer->getEvent()->getData('type');
+        if (! empty($type) && $type !== self::CACHE_TYPE) {
+            return;
         }
+
+        $this->_getFpc()->clean();
     }
 
     /**

--- a/app/code/community/Lesti/Fpc/Model/Observer/Clean.php
+++ b/app/code/community/Lesti/Fpc/Model/Observer/Clean.php
@@ -27,17 +27,14 @@ class Lesti_Fpc_Model_Observer_Clean
     {
         // type only exist for event adminhtml_cache_refresh_type
         $type = $observer->getEvent()->getData('type');
-        if (! empty($type) && $type !== self::CACHE_TYPE) {
+        if (! empty($type) && ($type !== self::CACHE_TYPE || ! $this->_getFpc()->isActive())) {
             return;
         }
 
         $this->_getFpc()->clean();
     }
 
-    /**
-     * @return Lesti_Fpc_Model_Fpc
-     */
-    protected function _getFpc()
+    protected function _getFpc(): Lesti_Fpc_Model_Fpc
     {
         return Mage::getSingleton('fpc/fpc');
     }

--- a/app/code/community/Lesti/Fpc/etc/config.xml
+++ b/app/code/community/Lesti/Fpc/etc/config.xml
@@ -121,6 +121,15 @@
                     </fpc_adminhtml_cache_flush_all>
                 </observers>
             </adminhtml_cache_flush_all>
+            <adminhtml_cache_flush_system>
+                <observers>
+                    <fpc_application_cache_flush_system>
+                        <class>fpc/observer_clean</class>
+                        <type>singleton</type>
+                        <method>flushFpc</method>
+                    </fpc_application_cache_flush_system>
+                </observers>
+            </adminhtml_cache_flush_system>
             <adminhtml_cache_refresh_type>
                 <observers>
                     <fpc_adminhtml_cache_refresh_type>
@@ -130,15 +139,6 @@
                     </fpc_adminhtml_cache_refresh_type>
                 </observers>
             </adminhtml_cache_refresh_type>
-            <application_clean_cache>
-                <observers>
-                    <fpc_application_clean_cache>
-                        <class>fpc/observer_clean</class>
-                        <type>singleton</type>
-                        <method>flushFpc</method>
-                    </fpc_application_clean_cache>
-                </observers>
-            </application_clean_cache>
             <cataloginventory_stock_item_save_after>
                 <observers>
                     <fpc_cataloginventory_stock_item_save_after>

--- a/app/code/community/Lesti/Fpc/etc/config.xml
+++ b/app/code/community/Lesti/Fpc/etc/config.xml
@@ -117,10 +117,28 @@
                     <fpc_adminhtml_cache_flush_all>
                         <class>fpc/observer_clean</class>
                         <type>singleton</type>
-                        <method>adminhtmlCacheFlushAll</method>
+                        <method>flushFpc</method>
                     </fpc_adminhtml_cache_flush_all>
                 </observers>
             </adminhtml_cache_flush_all>
+            <adminhtml_cache_refresh_type>
+                <observers>
+                    <fpc_adminhtml_cache_refresh_type>
+                        <class>fpc/observer_clean</class>
+                        <type>singleton</type>
+                        <method>flushFpc</method>
+                    </fpc_adminhtml_cache_refresh_type>
+                </observers>
+            </adminhtml_cache_refresh_type>
+            <application_clean_cache>
+                <observers>
+                    <fpc_application_clean_cache>
+                        <class>fpc/observer_clean</class>
+                        <type>singleton</type>
+                        <method>flushFpc</method>
+                    </fpc_application_clean_cache>
+                </observers>
+            </application_clean_cache>
             <cataloginventory_stock_item_save_after>
                 <observers>
                     <fpc_cataloginventory_stock_item_save_after>
@@ -220,28 +238,6 @@
             </updates>
         </layout>
     </frontend>
-    <adminhtml>
-        <events>
-            <controller_action_predispatch_adminhtml_cache_massRefresh>
-                <observers>
-                    <fpc_controller_action_predispatch_adminhtml_cache_massRefresh>
-                        <class>fpc/observer_clean</class>
-                        <type>singleton</type>
-                        <method>controllerActionPredispatchAdminhtmlCacheMassRefresh</method>
-                    </fpc_controller_action_predispatch_adminhtml_cache_massRefresh>
-                </observers>
-            </controller_action_predispatch_adminhtml_cache_massRefresh>
-            <controller_action_predispatch_adminhtml_cache_flushSystem>
-                <observers>
-                    <fpc_controller_action_predispatch_adminhtml_cache_flushSystem>
-                        <class>fpc/observer_clean</class>
-                        <type>singleton</type>
-                        <method>adminhtmlCacheFlushAll</method>
-                    </fpc_controller_action_predispatch_adminhtml_cache_flushSystem>
-                </observers>
-            </controller_action_predispatch_adminhtml_cache_flushSystem>
-        </events>
-    </adminhtml>
     <default>
         <system>
             <fpc>


### PR DESCRIPTION
This small PR simplifies the cache flush events and fixes an issue that `n98-magerun cache:clean fpc` is not working correctly, because of the missing `adminhtml_cache_refresh_type` event.

| Old Event | New Event | Notes |
| --- | --- | --- |
| `adminhtml_cache_flush_all` | (unchanged) | Button "Flush Cache Storage" |
| `controller_action_predispatch_adminhtml_cache_flushSystem`| `adminhtml_cache_flush_system>` | Button "Flush&Apply Updates" |
| `controller_action_predispatch_adminhtml_cache_massRefresh`  | `adminhtml_cache_refresh_type` | Grid Refresh |
| `core_clean_cache` | (unchanged) | Cron |